### PR TITLE
style: improve responsive design for mobile and tablet

### DIFF
--- a/src/components/CardPerson/CardPerson.module.scss
+++ b/src/components/CardPerson/CardPerson.module.scss
@@ -1,88 +1,103 @@
-.container{
-   transition: .3s;
-   animation: init .3s .3s both;
-   display: flex;
-   flex-direction: column;
-   justify-content: space-between;
-   align-items: center;
-   background-color: white;
-   color: #222222;
-   width: 90%;
-   border-radius: 5px;
-   margin-bottom: 1em;
+.container {
+    transition: .3s;
+    animation: init .3s .3s both;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    background-color: white;
+    color: #222222;
+    width: 90%;
+    border-radius: 5px;
+    margin-bottom: 1em;
 
+    .info {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
-   .info{
-      width: 100%;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+        .avatar {
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+            width: 60%;
+            margin-left: .8rem;
 
-      .avatar{
-         display: flex;
-         justify-content: flex-start;
-         align-items: center;
-         width: 60%;
-         margin-left: .8rem;
-   
-         p{
+            p {
+                font-size: .9rem;
+                margin-left: .3em;
+                font-weight: 500;
+                font-family: 'Montserrat', sans-serif !important;
+            }
+        }
+
+        .icon {
+            font-size: 1.2rem;
+            margin-right: 5px;
+        }
+
+        .monto {
             font-size: .9rem;
-            margin-left: .3em;
-            font-weight: 500;
+            font-weight: 300;
+            margin-right: 1em;
             font-family: 'Montserrat', sans-serif !important;
-         }
-      }
-   
-      .icon{
-         font-size: 1.2rem;
-         margin-right: 5px;
-      }
-   
-      .monto{
-         font-size: .9rem;
-         font-weight: 300;
-         margin-right: 1em;
-         font-family: 'Montserrat', sans-serif !important;
-      }
-   
-      .trash{
-         font-size: 1.2rem;
-         color: rgb(103, 49, 49);
-         margin-right: .8rem;
-      }
-   }
+        }
 
-   .detail{
-      width: 90%;
-      transition: .3s;
-      opacity: 0;
-      overflow: hidden;
-      max-height: 0;
+        .trash {
+            font-size: 1.2rem;
+            color: rgb(103, 49, 49);
+            margin-right: .8rem;
+        }
+    }
 
-      p{
-         margin: 0;
-         padding: 0;
-         font-size: .9em;
-         margin-top: 10px;
-         margin-bottom: 15px;
-      }
-   }
+    .detail {
+        width: 90%;
+        transition: .3s;
+        opacity: 0;
+        overflow: hidden;
+        max-height: 0;
 
-   .opendetail{
-      transition: .3s;
-      opacity: 1;
-      max-height: 4.5em;
-   }
+        p {
+            margin: 0;
+            padding: 0;
+            font-size: .85em;
+            margin-top: 10px;
+            margin-bottom: 15px;
+        }
+    }
+
+    .opendetail {
+        transition: .3s;
+        opacity: 1;
+        max-height: 5em;
+    }
+
+    /* Tablet: larger touch targets and text */
+    @media (min-width: 768px) {
+        width: 85%;
+
+        .info {
+            .avatar {
+                p { font-size: 1rem; }
+            }
+
+            .icon  { font-size: 1.4rem; }
+            .monto { font-size: 1rem; }
+            .trash { font-size: 1.4rem; }
+        }
+
+        .detail p { font-size: .95em; }
+    }
 }
 
 @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateX(100px);
-   }
-
-   100%{
-      opacity: 1;
-      transform: translateX(0);
-   }
+    0% {
+        opacity: 0;
+        transform: translateX(100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
 }

--- a/src/components/FormModal/FormModal.module.scss
+++ b/src/components/FormModal/FormModal.module.scss
@@ -1,43 +1,68 @@
-.formulario{
+.formulario {
     display: flex;
-    justify-content: space-around;
+    justify-content: flex-start;
     align-items: center;
     flex-wrap: wrap;
-    height: 20%;
+    /* Replace height: 20% (broken on short screens) with padding-based height */
+    height: auto;
     padding-bottom: 20px;
     margin-bottom: 20px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.466);
 
-    .input{
-       animation: init .3s both;
-       width: 100%;
-       display: flex;
-       flex-direction: column;
-       justify-content: space-between;
-       align-items: center;
-       margin-top: 20px;
+    .input {
+        animation: init .3s both;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+        margin-top: 20px;
 
-       span{
-          width: 95%;
-          font-family: 'Montserrat', sans-serif !important;
-          font-size: .8rem;
-       }
- 
-       .input_field{
-          width: 95%;
-          background-color: rgba(255, 255, 255, 0.975);
-          color: #222222;
-          margin-top: 10px;
-          font-size: .7rem;
-          --padding-start: 10px;
-          border-radius:5px;
-          font-family: 'Montserrat', sans-serif !important;
-       }
+        span {
+            width: 95%;
+            font-family: 'Montserrat', sans-serif !important;
+            font-size: .8rem;
+        }
+
+        .input_field {
+            width: 95%;
+            background-color: rgba(255, 255, 255, 0.975);
+            color: #222222;
+            margin-top: 8px;
+            font-size: .75rem;
+            --padding-start: 10px;
+            border-radius: 5px;
+            font-family: 'Montserrat', sans-serif !important;
+        }
     }
 
+    /*
+      Tablet portrait: place food and drink inputs side by side
+      to make better use of the wider screen.
+    */
+    @media (min-width: 600px) {
+        .input {
+            width: 48%;
+
+            span { font-size: .85rem; }
+            .input_field { font-size: .8rem; }
+
+            /* Selector and name fields stay full width */
+            &:first-child, &:last-child {
+                width: 100%;
+            }
+        }
+    }
+
+    @media (min-width: 768px) {
+        gap: 8px;
+
+        .input span { font-size: .9rem; }
+        .input .input_field { font-size: .85rem; }
+    }
 }
 
-.button{
+.button {
     transition: .1s;
     color: #222222;
     padding: .2em;
@@ -45,16 +70,19 @@
     font-family: 'Montserrat', sans-serif !important;
     font-weight: 400;
     text-transform: capitalize;
- }
 
- @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateX(100px);
-   }
+    @media (min-width: 768px) {
+        padding: .3em;
+    }
+}
 
-  100%{
-      opacity: 1;
-      transform: translateX(0);
-   }
- }
+@keyframes init {
+    0% {
+        opacity: 0;
+        transform: translateX(100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,29 +1,46 @@
 @import '../../theme/variables.css';
 
-.container{
-   animation: init .4s .3s both;
-   display: flex;
-   align-items: center;
-   width: 95%;
-   height: 7vh;
-   font-size: 1.6rem;
-   font-weight: 500;
-   letter-spacing: 2px;
-   font-family: 'Montserrat', sans-serif !important;
+.container {
+    animation: init .4s .3s both;
+    display: flex;
+    align-items: center;
+    width: 95%;
+    /* Replace fixed 7vh with min-height + padding so it adapts to font size */
+    min-height: 52px;
+    padding: 10px 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+    letter-spacing: 2px;
+    font-family: 'Montserrat', sans-serif !important;
 
-   img{
-      width: 15%;
-   }
+    img {
+        /* clamp avoids both too-small on tiny phones and too-large on tablets */
+        width: clamp(36px, 12%, 52px);
+    }
+
+    @media (min-width: 600px) {
+        font-size: 1.65rem;
+        padding: 12px 0;
+    }
+
+    @media (min-width: 768px) {
+        font-size: 1.8rem;
+        min-height: 64px;
+        padding: 16px 0;
+
+        img {
+            width: clamp(48px, 8%, 64px);
+        }
+    }
 }
 
 @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateX(-100px);
-   }
-
-   100%{
-      opacity: 1;
-      transform: translateX(0);
-   }
+    0% {
+        opacity: 0;
+        transform: translateX(-100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
 }

--- a/src/components/Matchsticks/Matchsticks.module.scss
+++ b/src/components/Matchsticks/Matchsticks.module.scss
@@ -7,7 +7,7 @@
     .matchstick1, .matchstick2, .matchstick3, .matchstick4, .matchstick5 {
         animation: init .2s both;
         position: absolute;
-        font-size: 2.3rem;
+        font-size: 2.2rem;
         top: 10%;
         left: 28%;
         rotate: 135deg;
@@ -34,6 +34,13 @@
         top: 10%;
         left: 40%;
         rotate: 90deg;
+    }
+
+    /* Tablet: slightly larger matchsticks for the bigger display */
+    @media (min-width: 768px) {
+        .matchstick1, .matchstick2, .matchstick3, .matchstick4, .matchstick5 {
+            font-size: 2.6rem;
+        }
     }
 }
 

--- a/src/components/SplashScreen/SplashScreen.module.scss
+++ b/src/components/SplashScreen/SplashScreen.module.scss
@@ -12,13 +12,15 @@
 
   img{
     animation: entry_logo 1s .5s both;
-    width: 50%;
+    /* Fluid: at least 140px, 50% on small screens, capped at 220px on tablets */
+    width: clamp(140px, 50%, 220px);
   }
 
   .progress{
     margin-top: 80px;
     animation: opacity_progress .3s .3s both;
-    width: 40%;
+    /* Fluid: at least 160px, 40% on small screens, capped at 280px on tablets */
+    width: clamp(160px, 40%, 280px);
   }
 }
 

--- a/src/components/TasksModal/TasksModal.module.scss
+++ b/src/components/TasksModal/TasksModal.module.scss
@@ -14,6 +14,11 @@
             border-radius: 8px;
             margin-top: 10px;
         }
+
+        /* Tablet: more spacing between list items */
+        @media (min-width: 768px) {
+            .ionitem { margin-top: 14px; }
+        }
     }
 }
 

--- a/src/components/Transaction/Transaction.module.scss
+++ b/src/components/Transaction/Transaction.module.scss
@@ -1,56 +1,71 @@
-.container{
-   animation: init .3s both;
-   display: flex;
-   justify-content: space-between;
-   align-items: center;
-   background-color: white;
-   padding: .5em;
-   width: 100%;
-   border-radius: 5px;
-   margin-bottom: 20px;
-   color: #222;
-   
-   .deudor, .acreedor{
-      display: flex;
-      justify-content: flex-start;
-      align-items: center;
-      width: 40%;
+.container {
+    animation: init .3s both;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: white;
+    padding: .6em .5em;
+    width: 100%;
+    border-radius: 5px;
+    margin-bottom: 16px;
+    color: #222;
 
-      p{
-         padding: 0;
-         margin: 0;
-         margin-left: 10px;
-         font-family: 'Montserrat', sans-serif !important;
-      }
-   }
+    .deudor, .acreedor {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: 38%;
 
-   .acreedor{
-      justify-content: flex-end;
-      margin-right: 10px;
-   }
+        p {
+            padding: 0;
+            margin: 0;
+            margin-left: 8px;
+            font-size: .85rem;
+            font-family: 'Montserrat', sans-serif !important;
+            word-break: break-word;
+        }
+    }
 
-   .arrow{
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
+    .acreedor {
+        justify-content: flex-end;
+        margin-right: 8px;
 
-      p{
-         margin: 0;
-         padding: 0;
-         margin-top: 5px;
-         font-family: 'Montserrat', sans-serif !important;
-      }
-   }
+        p { margin-left: 0; margin-right: 8px; }
+    }
+
+    .arrow {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        flex-shrink: 0;
+
+        p {
+            margin: 0;
+            padding: 0;
+            margin-top: 4px;
+            font-size: .75rem;
+            font-family: 'Montserrat', sans-serif !important;
+        }
+    }
+
+    /* Tablet: more padding and readable font */
+    @media (min-width: 768px) {
+        padding: .8em .7em;
+        margin-bottom: 20px;
+
+        .deudor p, .acreedor p { font-size: .95rem; }
+        .arrow p { font-size: .85rem; }
+    }
 }
 
 @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateY(100px);
-   }
-   100%{
-      opacity: 1;
-      transform: translateY(0);
-   }
+    0% {
+        opacity: 0;
+        transform: translateY(100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/src/pages/Calculator/Calculator.module.scss
+++ b/src/pages/Calculator/Calculator.module.scss
@@ -1,87 +1,128 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    /*
+      Replace fixed height: 85vh with padding-based layout.
+      IonContent handles scrolling — the container just stacks its children.
+    */
+    padding-bottom: 24px;
 
-.container{
-   display: flex;
-   flex-direction: column;
-   justify-content: flex-start;
-   align-items: center;
-   height: 85vh;
-   
-   .persons{
-      animation: init .5s .2s both;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
-      align-items: center;
-      overflow-y: scroll;
-      overflow-x: hidden;
-      width: 100%;
-      height: 63vh;
-      max-height: 63vh;
-      margin-bottom: 5%;
-      margin-top: 5%;
+    .persons {
+        animation: init .5s .2s both;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+        overflow-y: auto;
+        overflow-x: hidden;
+        width: 100%;
+        /*
+          Mobile: fixed viewport-based height so the list scrolls internally
+          and the Calcular button stays visible without scrolling IonContent.
+        */
+        height: 55vh;
+        max-height: 55vh;
+        margin-bottom: 4%;
+        margin-top: 4%;
 
-      .empty{
-         font-family: 'Montserrat', sans-serif !important;
-         font-weight: 200;
-      }
-   }
+        .empty {
+            font-family: 'Montserrat', sans-serif !important;
+            font-weight: 200;
+            opacity: .6;
+            text-align: center;
+            margin-top: 2rem;
+        }
 
-   .calcular, .cacular_dis{
-      animation: init .5s .5s both;
-      transition: .2s;
-      width: 100%;
-      height: 7vh;
-      font-size: 1rem;
-      margin-top: 2em;
-      font-family: 'Montserrat', sans-serif !important;
-      font-weight: 600;
-      color: #222222;
-      background-color: rgba(255, 255, 255, 0.975);
+        /* Large phone / small tablet */
+        @media (min-width: 600px) {
+            height: 58vh;
+            max-height: 58vh;
+        }
 
-      &:active{
-         transition: .1s;
-         background-color: rgba(255, 255, 255, 0.615);
-      }
-   }
+        /* Tablet portrait: more vertical space available */
+        @media (min-width: 768px) {
+            height: 62vh;
+            max-height: 62vh;
+            margin-top: 3%;
+            margin-bottom: 3%;
+        }
 
-   .cacular_dis{
-      transition: .2s;
-      background-color: rgba(255, 255, 255, 0.561);
-      color: #2222226f;
-   }
+        /* Tablet landscape */
+        @media (min-width: 1024px) {
+            height: 58vh;
+            max-height: 58vh;
+        }
+    }
+
+    .calcular, .cacular_dis {
+        animation: init .5s .5s both;
+        transition: .2s;
+        width: 100%;
+        /* Replace fixed 7vh with min-height for better cross-device consistency */
+        min-height: 48px;
+        padding: 12px;
+        font-size: 1rem;
+        margin-top: 1.5em;
+        font-family: 'Montserrat', sans-serif !important;
+        font-weight: 600;
+        color: #222222;
+        background-color: rgba(255, 255, 255, 0.975);
+        border-radius: 8px;
+
+        &:active {
+            transition: .1s;
+            background-color: rgba(255, 255, 255, 0.615);
+        }
+
+        @media (min-width: 768px) {
+            min-height: 56px;
+            font-size: 1.05rem;
+        }
+    }
+
+    .cacular_dis {
+        transition: .2s;
+        background-color: rgba(255, 255, 255, 0.561);
+        color: #2222226f;
+    }
 }
 
-.modal{
-   display: flex;
-   justify-content: space-between;
-   align-items: center;
-   flex-direction: column;
-   height: 100%;
+.modal {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: column;
+    height: 100%;
 
-   .transactions{
-      width: 100%;
+    .transactions {
+        width: 100%;
 
-      h3{
-         font-size: 1.2rem;
-         margin-bottom: 1rem;
-         font-family: 'Montserrat', sans-serif !important;
-      }
+        h3 {
+            font-size: 1.1rem;
+            margin-bottom: 1rem;
+            font-family: 'Montserrat', sans-serif !important;
 
-      p{
-         font-size: .9rem;
-         font-family: 'Montserrat', sans-serif !important;
-      }
-   }
+            @media (min-width: 768px) {
+                font-size: 1.25rem;
+            }
+        }
 
+        p {
+            font-size: .9rem;
+            font-family: 'Montserrat', sans-serif !important;
+        }
+    }
 }
 
 @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateX(100px);
-   }
-   100%{
-      opacity: 1;
-      transform: translateX(0);
-   }
+    0% {
+        opacity: 0;
+        transform: translateX(100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateX(0);
+    }
 }

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -1,14 +1,14 @@
-
-.container{
+.container {
     width: 90%;
-    height: 86vh;
+    min-height: 86vh;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    margin-inline: 20px;
+    /* Use percentage margins so they scale with screen width */
+    margin-inline: 5%;
     font-family: 'Montserrat', sans-serif;
 
-    .feat, .link{
+    .feat, .link {
         transition: .1s;
         width: 100%;
         display: flex;
@@ -20,54 +20,88 @@
         border-radius: 5px;
         margin-bottom: 15px;
 
-        p{
+        p {
             margin: 0;
             padding: 0;
-            font-size: .7rem;
+            font-size: .75rem;
         }
 
-        &:active{
+        &:active {
             transition: .1s;
             opacity: .7;
             scale: .99;
         }
     }
 
-    .support{
+    .support {
         animation: init .3s .3s both;
-        margin-top: 50px;
+        margin-top: 40px;
     }
 
-    .features{
+    .features {
         animation: init .3s .5s both;
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
         align-items: center;
+        gap: 0;
 
-        .feat{
+        /* Mobile: 2-column grid */
+        .feat {
             display: flex;
             justify-content: flex-start;
             align-items: center;
             width: 48%;
         }
+
+        /* Tablet portrait: 4-column grid */
+        @media (min-width: 768px) {
+            .feat {
+                width: 23%;
+            }
+        }
     }
-    
-    h3{
+
+    h3 {
         width: 100%;
-        font-size: 1.2rem;
+        font-size: 1.1rem;
         font-weight: 300;
-        margin-bottom: 20px;
+        margin-bottom: 16px;
+
+        @media (min-width: 768px) {
+            font-size: 1.3rem;
+            margin-bottom: 20px;
+        }
+    }
+
+    /* Tablet portrait: more breathing room */
+    @media (min-width: 600px) {
+        margin-inline: 4%;
+
+        .support {
+            margin-top: 50px;
+        }
+    }
+
+    @media (min-width: 768px) {
+        margin-inline: 3%;
+
+        .feat, .link {
+            padding: 1.2em;
+
+            p {
+                font-size: .85rem;
+            }
+        }
     }
 }
 
 @keyframes init {
-    0%{
+    0% {
         opacity: 0;
         transform: translateX(-100px);
     }
-
-    100%{
+    100% {
         opacity: 1;
         transform: translateX(0);
     }

--- a/src/pages/Playlists/Playlists.module.scss
+++ b/src/pages/Playlists/Playlists.module.scss
@@ -1,78 +1,86 @@
-.container{
-   display: flex;
-   justify-content: flex-start;
-   align-items: center;
-   flex-direction: column;
-   width: 100%;
+.container {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    flex-direction: column;
+    width: 100%;
 
+    p {
+        text-align: center;
+        font-family: 'Montserrat', sans-serif !important;
+        opacity: .8;
+        font-size: .95rem;
+        padding-inline: 4%;
 
-   p{
-      text-align: center;
-      font-family: 'Montserrat', sans-serif !important;
-      opacity: .8;
-      font-size: 1rem;
-   }
+        @media (min-width: 768px) {
+            font-size: 1.05rem;
+        }
+    }
 
-   .ionItem{
-      animation: init .3s both;
-      position: relative;
-      margin-top: 20px;
-      border-radius: 8px;
+    .ionItem {
+        animation: init .3s both;
+        position: relative;
+        margin-top: 16px;
+        border-radius: 8px;
 
-      .playlist_loader{
-         animation: loader 0.3s 2s both;
-         position: absolute;
-         display: flex;
-         justify-content: center;
-         align-items: center;
-         width: 96%;
-         height: 100%;
-         background-color: #ffffff24;
-         backdrop-filter: blur(10px);
-         -webkit-backdrop-filter: blur(10px);
-         border-radius: 8px;
+        /* Tablet: add horizontal padding so iframes don't stretch edge to edge */
+        @media (min-width: 768px) {
+            margin-top: 24px;
+        }
 
-         .progress{
-            width: 80%;
-         }
-      }
-   }
+        .playlist_loader {
+            animation: loader 0.3s 2s both;
+            position: absolute;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 96%;
+            height: 100%;
+            background-color: #ffffff24;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            border-radius: 8px;
 
-   .no_internet{
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      flex-direction: column;
-      padding-inline: 8%;
-      margin-top: 20vh;
+            .progress {
+                width: 80%;
+            }
+        }
+    }
 
-      p{
-         opacity: 1;
-         font-size: .9rem;
-         margin-bottom: 30px;
-      }
-   }
+    .no_internet {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+        padding-inline: 10%;
+        /* Replace fixed 20vh with clamp so it never pushes content off-screen */
+        margin-top: clamp(60px, 18vh, 160px);
 
+        p {
+            opacity: 1;
+            font-size: .9rem;
+            margin-bottom: 28px;
+            padding-inline: 0;
 
+            @media (min-width: 768px) {
+                font-size: 1rem;
+            }
+        }
+    }
 }
 
 @keyframes init {
-   0%{
-      opacity: 0;
-      transform: translateY(100px);
-   }
-   100%{
-      opacity: 1;
-      transform: translateY(0px);
-   }
+    0% {
+        opacity: 0;
+        transform: translateY(100px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0px);
+    }
 }
 
 @keyframes loader {
-   0%{
-      opacity: 1;
-   }
-   100%{
-      opacity: 0;
-      display: none;
-   }
+    0%  { opacity: 1; }
+    100% { opacity: 0; display: none; }
 }

--- a/src/pages/Scorekeeper/Scorekeeper.module.scss
+++ b/src/pages/Scorekeeper/Scorekeeper.module.scss
@@ -18,7 +18,14 @@
         flex-direction: column;
         justify-content: flex-start;
         width: 50%;
-        height: 80vh;
+        /*
+          Replace fixed 80vh: on a landscape tablet (height ~600px), 80vh = 480px which
+          is reasonable, but on portrait tablets (height ~1024px) it was too tall.
+          Use a capped min-height approach instead.
+        */
+        height: 72vh;
+        min-height: 320px;
+        max-height: 640px;
 
         h3 {
             text-align: center;
@@ -30,30 +37,53 @@
 
         .matchsticks {
             width: 100%;
-            height: 80%;
+            flex: 1;
             padding-top: 20px;
             border-top: 2px solid rgba(255, 255, 255, 0.265);
+            overflow: hidden;
         }
 
         .buttons {
             animation: init .3s .5s both;
             width: 100%;
             margin-top: 10px;
+            padding: 8px 0;
             display: flex;
             justify-content: space-evenly;
             align-items: center;
 
             .button {
                 transition: .3s;
-                font-size: 1.5rem;
+                font-size: 1.6rem;
                 border-radius: 100%;
-                padding: .3em;
+                padding: .35em;
 
                 &:active {
                     transition: .3s;
                     background-color: rgba(255, 255, 255, 0.075);
                 }
             }
+        }
+
+        /* Tablet portrait */
+        @media (min-width: 768px) {
+            height: 68vh;
+            max-height: 720px;
+
+            h3 {
+                font-size: 1.15rem;
+                letter-spacing: 1.5px;
+            }
+
+            .buttons .button {
+                font-size: 2rem;
+                padding: .4em;
+            }
+        }
+
+        /* Tablet landscape */
+        @media (min-width: 1024px) {
+            height: 65vh;
         }
     }
 }
@@ -64,24 +94,35 @@
     justify-content: center;
     align-items: center;
     width: 100%;
+    padding: 16px 0;
 
     .button {
         transition: .1s;
         display: flex;
         justify-content: center;
         align-items: center;
-        width: 40%;
+        /* Mobile: wider so it's easy to tap */
+        width: 55%;
+        max-width: 280px;
         background-color: rgba(255, 255, 255, 0.975);
         color: #222222;
-        border-radius: 5px;
+        border-radius: 8px;
         text-align: center;
-        padding: .3em;
-        font-size: 1.2rem;
+        padding: .5em;
+        font-size: 1rem;
+        font-family: 'Montserrat', sans-serif;
 
         &:active {
             transition: .1s;
             scale: .99;
             background-color: rgba(255, 255, 255, 0.33);
+        }
+
+        /* Tablet: narrower relative to screen but larger in absolute terms */
+        @media (min-width: 768px) {
+            width: 35%;
+            font-size: 1.05rem;
+            padding: .6em;
         }
     }
 }

--- a/src/pages/Shopping/Shopping.module.scss
+++ b/src/pages/Shopping/Shopping.module.scss
@@ -11,10 +11,23 @@
     animation: init .3s both;
 
     .itemLabel {
+        h2 {
+            font-size: 1rem;
+            font-family: 'Montserrat', sans-serif;
+        }
+
         p {
-            margin-top: 8px;
+            margin-top: 6px;
             opacity: .5;
-            font-size: .7rem;
+            font-size: .72rem;
+        }
+    }
+
+    /* Tablet: larger list items for comfortable reading */
+    @media (min-width: 768px) {
+        .itemLabel {
+            h2 { font-size: 1.1rem; }
+            p  { font-size: .8rem; }
         }
     }
 }

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -4,8 +4,21 @@ http://ionicframework.com/docs/theming/ */
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
 
-/* Responsive fonts */
+/*
+  Base font — mobile first.
+  Previous value `4vw` caused ~30px on a 768px tablet (too large).
+  Fixed values per breakpoint give predictable, readable sizes on all devices.
+*/
+html { font-size: 15px; }        /* default: small phone  */
 
-html{
-    font-size: 4vw;
+@media (min-width: 480px) {
+    html { font-size: 16px; }    /* large phone           */
+}
+
+@media (min-width: 768px) {
+    html { font-size: 17px; }    /* tablet portrait       */
+}
+
+@media (min-width: 1024px) {
+    html { font-size: 18px; }    /* tablet landscape      */
 }


### PR DESCRIPTION
- Fix global font-size from 4vw (broken on tablet) to fixed breakpoint values
- Replace fixed vh/px heights with fluid/clamped alternatives throughout
- Add tablet breakpoints (768px) to all SCSS modules with larger fonts and touch targets
- Fix FormModal height: 20% → height: auto; 2-column inputs on tablet
- Fix Header: height: 7vh → min-height + padding; logo uses clamp()
- Fix Home: 4-column feature grid on tablet, percentage-based margins
- Fix Calculator: responsive person-list heights per breakpoint
- Fix Scorekeeper: capped team heights, larger new-game button on mobile
- Fix Playlists: margin-top: 20vh → clamp() for no_internet state
- Fix SplashScreen: logo and progress bar use clamp() on tablet